### PR TITLE
Set icon stroke color to titleColor

### DIFF
--- a/Classes/TWMessageBarManager.m
+++ b/Classes/TWMessageBarManager.m
@@ -567,7 +567,11 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
         {
             if ([styleSheet respondsToSelector:@selector(iconImageForMessageType:)])
             {
-                [[styleSheet iconImageForMessageType:self.messageType] drawInRect:CGRectMake(xOffset, yOffset, iconSize.width, iconSize.height)];
+                UIImage *image = [styleSheet iconImageForMessageType:self.messageType];
+                if (image.renderingMode == UIImageRenderingModeAlwaysTemplate) {
+                    [[self titleColor] set];
+                }
+                [image drawInRect:CGRectMake(xOffset, yOffset, iconSize.width, iconSize.height)];
             }
         }
         CGContextRestoreGState(context);


### PR DESCRIPTION
Set the stroke only if the image is rendering mode always template; enables the use of template images in the banner with the correct color.