### PR TITLE
Made layout fixes for iPhone X safe area

### DIFF
--- a/Classes/TWMessageBarManager.m
+++ b/Classes/TWMessageBarManager.m
@@ -635,10 +635,11 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
 #pragma mark - Getters
 
 //required for iPhone X
--(CGFloat)topSafeArea{
+- (CGFloat)topSafeArea {
     if (@available(iOS 11.0, *)) {
         return [[[UIApplication sharedApplication] delegate] window].safeAreaInsets.top;
-    }else{
+    }
+    else {
         return 0.0f;
     }
 }

--- a/Classes/TWMessageBarManager.m
+++ b/Classes/TWMessageBarManager.m
@@ -561,7 +561,7 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
         
         CGFloat xOffset = outerHorizontalPadding;
         CGSize iconSize = [self iconSize];
-        CGFloat yOffset = (rect.size.height / 2) - (iconSize.height / 2);
+        CGFloat yOffset = ((rect.size.height + [self statusBarOffset]) / 2) - (iconSize.height / 2);
         
         CGContextSaveGState(context);
         {
@@ -634,6 +634,15 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
 
 #pragma mark - Getters
 
+//required for iPhone X
+-(CGFloat)topSafeArea{
+    if (@available(iOS 11.0, *)) {
+        return [[[UIApplication sharedApplication] delegate] window].safeAreaInsets.top;
+    }else{
+        return 0.0f;
+    }
+}
+
 - (CGFloat)height
 {
     CGSize titleLabelSize = [self titleSize];
@@ -670,7 +679,8 @@ static UIColor *kTWDefaultMessageBarStyleSheetInfoStrokeColor = nil;
 - (CGFloat)statusBarOffset
 {
     if (self.statusBarHidden) {
-        return 0.0f;
+        //24 is the difference between iPhone x status bar and previous status bars
+        return [self topSafeArea] > 0.0f ? 24.0f : 0.0f;
     }
     else {
         return [[UIDevice currentDevice] tw_isRunningiOS7OrLater] ? [self statusBarFrame].size.height : 0.0;


### PR DESCRIPTION
This is a quick fix for the iPhone X that takes into account the 'Safe area' at the top of the screen. It's tricky to make a more general fix as the library currently uses hardcoded margin values to get the messages to display to the height of the navbar + statusbar. In the future, if apple continue to release different shaped/sized screens we should probably overhaul the way the height is calculated or perhaps even move away from showing notifications at the top of the screen.